### PR TITLE
Bumping CQL and CqlSh Versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:2.7-alpine3.8
 
 WORKDIR /scripts
 
-ENV CQLVERSION="3.4.4" \
+ENV CQLVERSION="3.4.5" \
     CQLSH_HOST="cassandra" \
     CQLSH_PORT="9042"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV CQLVERSION="3.4.5" \
     CQLSH_HOST="cassandra" \
     CQLSH_PORT="9042"
 
-RUN pip install -Ivq cqlsh==5.0.4 \
+RUN pip install -Ivq cqlsh==6.0.0 \
     && apk add --no-cache bash \
     && echo 'alias cqlsh="cqlsh --cqlversion ${CQLVERSION} $@"' >> /.bashrc \
     && mkdir /.cassandra

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # defaults for cqlsh
-export CQLVERSION=${CQLVERSION:-"3.4.4"}
+export CQLVERSION=${CQLVERSION:-"3.4.5"}
 export CQLSH_HOST=${CQLSH_HOST:-"cassandra"}
 export CQLSH_PORT=${CQLSH_PORT:-"9042"}
 


### PR DESCRIPTION
The instructions on [https://cassandra.apache.org/_/quickstart.html](Get Started with Apache Cassandra) no longer work due to version changes. This PR updates versions in order for the tutorial to work correct.

Test image: https://hub.docker.com/r/hattan/docker-cqlsh/