### PR TITLE
Python image not alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV CQLVERSION="3.4.6" \
     CQLSH_PORT="9042"
 
 RUN pip install -Ivq cqlsh==6.0.0 \
+    pip install futures \
     && echo 'alias cqlsh="cqlsh --cqlversion ${CQLVERSION} $@"' >> /.bashrc \
     && mkdir /.cassandra
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:2.7
 
 WORKDIR /scripts
 
-ENV CQLVERSION="3.4.4" \
+ENV CQLVERSION="3.4.6" \
     CQLSH_HOST="cassandra" \
     CQLSH_PORT="9042"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV CQLVERSION="3.4.6" \
     CQLSH_PORT="9042"
 
 RUN pip install -Ivq cqlsh==5.0.4 \
-    && apk add --no-cache bash \
     && echo 'alias cqlsh="cqlsh --cqlversion ${CQLVERSION} $@"' >> /.bashrc \
     && mkdir /.cassandra
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-alpine3.8
+FROM python:2.7
 
 WORKDIR /scripts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV CQLVERSION="3.4.6" \
     CQLSH_HOST="cassandra" \
     CQLSH_PORT="9042"
 
-RUN pip install -Ivq cqlsh==5.0.4 \
+RUN pip install -Ivq cqlsh==6.0.0 \
     && echo 'alias cqlsh="cqlsh --cqlversion ${CQLVERSION} $@"' >> /.bashrc \
     && mkdir /.cassandra
 


### PR DESCRIPTION
 - Python resilience in base image - particularly on M1 - MacOS ARM - Ventura
 - Make cqlsh version match that in latest cassandra image
 - remove redundant bash install - no longer required/works if not on Alpine
 - Update cqlsh version
 - Add library for cqlsh required on python 2.7