### PR TITLE
Fix typo in K8S job sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Connected to Test Cluster at localhost:9042.
 
 ```yaml
 apiVersion: batch/v1
-king: Job
+kind: Job
 metadata:
   name: load-cql-files
 spec:


### PR DESCRIPTION
Problem: K8S job sample failed.

Fix: Fix typo from "king" to "kind".